### PR TITLE
Fix: Template selection from URL parameter now works correctly

### DIFF
--- a/src/app/migrations/new/page.tsx
+++ b/src/app/migrations/new/page.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { MigrationProjectBuilder } from '@/components/features/migrations/MigrationProjectBuilder';
+
+function MigrationBuilderWithParams() {
+  const searchParams = useSearchParams();
+  const templateId = searchParams.get('template');
+  
+  return <MigrationProjectBuilder defaultTemplateId={templateId} />;
+}
 
 export default function NewMigrationPage() {
   return (
@@ -22,7 +30,9 @@ export default function NewMigrationPage() {
         </p>
       </div>
 
-      <MigrationProjectBuilder />
+      <Suspense fallback={<div>Loading...</div>}>
+        <MigrationBuilderWithParams />
+      </Suspense>
     </div>
   );
 } 


### PR DESCRIPTION
## Summary
- Fixed template selection so clicking "Use Template" buttons properly pre-selects the chosen template
- Added support for reading `template` query parameter from URL
- Implemented proper priority order for template selection

## Changes
- Updated `NewMigrationPage` to read the template query parameter using `useSearchParams` hook
- Modified `MigrationProjectBuilder` to accept a `defaultTemplateId` prop
- Enhanced template selection logic with clear priority order:
  1. Template ID from URL parameter (if valid)
  2. Interpretation rules template (fallback)
  3. First available template (final fallback)

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint passes with no errors
- [x] All unit tests pass
- [ ] Manual testing: Click "Use Template" on various templates and verify correct selection
- [ ] Manual testing: Navigate directly to `/migrations/new?template=<id>` and verify selection
- [ ] Manual testing: Navigate to `/migrations/new` without query param and verify default behavior

## Related Issue
Fixes #197

🤖 Generated with [Claude Code](https://claude.ai/code)